### PR TITLE
ESLintの導入 (Issue #2)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "airbnb-base"
+}

--- a/app.js
+++ b/app.js
@@ -1,11 +1,11 @@
-var express = require('express');
-var app = express();
-var port = process.env.PORT || 3000;
+const express = require('express');
+const app = express();
+const port = process.env.PORT || 3000;
 
-app.get('/', function (req, res) {
+app.get('/', (req, res) => {
   res.send('OK');
 });
 
-app.listen(port, function () {
-  console.log('Listening on port ' + port);
+app.listen(port, () => {
+  console.log(`Listening on port ${port}`);
 });

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "app.js",
   "scripts": {
     "start": "node app.js",
+    "lint": "eslint .",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -20,5 +21,10 @@
   "homepage": "https://github.com/kaigi-no-owari/kaigi-no-owari-server",
   "dependencies": {
     "express": "^4.14.0"
+  },
+  "devDependencies": {
+    "eslint": "^2.13.1",
+    "eslint-config-airbnb-base": "^3.0.1",
+    "eslint-plugin-import": "^1.9.2"
   }
 }


### PR DESCRIPTION
JavaScriptコードの静的解析のために ESLint を導入しました。

ES2015 (ES6) でやりたかったので、Airbnb のルールセットを使うようにしています。
また、`no-console` 以外の警告もあわせて修正済みです。

``` sh
$ npm install
$ npm run lint
```
