### PR TITLE
Travis CI の導入 (Issue #3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - "node"
+  - "6"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # kaigi-no-owari-server
 スケジュール情報を配信するAPIサーバー
+
+[![Build Status](https://travis-ci.org/kaigi-no-owari/kaigi-no-owari-server.svg?branch=master)](https://travis-ci.org/kaigi-no-owari/kaigi-no-owari-server)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node app.js",
     "lint": "eslint .",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "eslint ."
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Travis CI を使って自動的にビルドするようにしました。現状、ESLint で静的解析するだけです。
- https://travis-ci.org/kaigi-no-owari/kaigi-no-owari-server

また、READMEにビルドステータスのバッジも表示するようにしました。
`master` ブランチのステータスを表示するので、まだ `unknown` になっていると思います。
