### PR TITLE
スケジュール登録APIの実装 (Issue #6)

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,21 +1,14 @@
 const express = require('express');
+const bodyParser = require('body-parser');
+const routes = require('./routes/meetings');
 const app = express();
-const pgp = require('pg-promise')();
-const db = pgp(process.env.DATABASE_URL);
 const port = process.env.PORT || 3000;
+
+app.use(bodyParser.json());
+app.use('/api/meetings', routes);
 
 app.get('/', (req, res) => {
   res.send('OK');
-});
-
-app.get('/db', (req, res) => {
-  db.any('select * from information_schema.schemata')
-    .then(data => {
-      res.send(data);
-    })
-    .catch(error => {
-      res.send(error);
-    });
 });
 
 app.listen(port, () => {

--- a/app.js
+++ b/app.js
@@ -11,6 +11,19 @@ app.get('/', (req, res) => {
   res.send('OK');
 });
 
+// catch 404 and forward to error handler
+app.use((req, res, next) => {
+  const err = new Error('Not Found');
+  err.status = 404;
+  next(err);
+});
+
+// error handler
+app.use((err, req, res, next) => { // eslint-disable-line no-unused-vars
+  const status = err.status || 500;
+  res.status(status).json({ status, message: err.message });
+});
+
 app.listen(port, () => {
   console.log(`Listening on port ${port}`);
 });

--- a/migrations/20160623235058-create-meetings.js
+++ b/migrations/20160623235058-create-meetings.js
@@ -1,6 +1,7 @@
 exports.up = (db, callback) => {
   db.createTable('meetings', {
-    room_id: { type: 'string', primaryKey: true },
+    id: { type: 'int', primaryKey: true, autoIncrement: true },
+    room_id: 'string',
     title: 'string',
     description: 'string',
     start_at: { type: 'datetime', notNull: true },

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/kaigi-no-owari/kaigi-no-owari-server",
   "dependencies": {
+    "body-parser": "^1.15.2",
     "db-migrate": "^0.9.25",
     "express": "^4.14.0",
     "pg-promise": "^4.8.0"

--- a/routes/meetings.js
+++ b/routes/meetings.js
@@ -3,7 +3,7 @@ const router = express.Router(); // eslint-disable-line new-cap
 const pgp = require('pg-promise')();
 const db = pgp(process.env.DATABASE_URL);
 
-router.post('/', (req, res) => {
+router.post('/', (req, res, next) => {
   // 単純に全データ削除してから登録し直す
   db.tx(t => {
     const queries = [];
@@ -21,11 +21,10 @@ router.post('/', (req, res) => {
     return t.batch(queries);
   })
   .then(() => {
-    res.json('ok'); // FIXME
+    res.status(201).json({ status: 201, message: 'Created' });
   })
-  .catch(error => {
-    console.error(error);
-    res.json('error'); // FIXME
+  .catch(err => {
+    next(err);
   });
 });
 

--- a/routes/meetings.js
+++ b/routes/meetings.js
@@ -1,0 +1,32 @@
+const express = require('express');
+const router = express.Router(); // eslint-disable-line new-cap
+const pgp = require('pg-promise')();
+const db = pgp(process.env.DATABASE_URL);
+
+router.post('/', (req, res) => {
+  // 単純に全データ削除してから登録し直す
+  db.tx(t => {
+    const queries = [];
+    queries.push(t.none('DELETE FROM meetings'));
+    if (Array.isArray(req.body)) {
+      const now = new Date();
+      req.body.forEach(m => {
+        queries.push(t.none('INSERT INTO ' +
+          'meetings (id, room_id, title, description, start_at, end_at, registered_at)' +
+          'values (DEFAULT, $1, $2, $3, $4, $5, $6)',
+          [m.room_id, m.title, m.description, m.start_at, m.end_at, now]
+        ));
+      });
+    }
+    return t.batch(queries);
+  })
+  .then(() => {
+    res.json('ok'); // FIXME
+  })
+  .catch(error => {
+    console.error(error);
+    res.json('error'); // FIXME
+  });
+});
+
+module.exports = router;


### PR DESCRIPTION
Issue #6 

登録用のエンドポイントを実装しました。環境構築は `README.md` を参照してください。
- POST /api/meetings

登録に成功すると `201` が返ります。例えば次の通り。

``` sh
$ curl -H "Content-Type: application/json" -X POST -d '[ {"room_id": "A", "start_at": "2016-06-21T01:00:00.000Z", "end_at": "2016-06-21T02:00:00.000Z", "title": "foo", "description": "bar"} ]' http://localhost:5000/api/meetings
{"status":201,"message":"Created"}

$ psql -c "select * from meetings" <DB名>
 id | room_id | title | description |      start_at       |       end_at        |    registered_at
----+---------+-------+-------------+---------------------+---------------------+---------------------
 23 | A       | foo   | bar         | 2016-06-21 01:00:00 | 2016-06-21 02:00:00 | 2016-06-26 13:30:11
(1 row)
```

登録に失敗した場合も JSON でエラーが返ります。

``` sh
$ curl -H "Content-Type: application/json" -X POST -d '' http://localhost:5000/api/meeting
{"status":404,"message":"Not Found"}
```
