### PR TITLE
スケジュール取得APIの実装 (Issue #7)

### DIFF
--- a/routes/meetings.js
+++ b/routes/meetings.js
@@ -10,7 +10,11 @@ function findMeetings(req) {
     to: req.query.to,
     limit: req.query.limit,
   };
-  let sql = 'SELECT * FROM meetings WHERE $(from) <= end_at';
+  let sql = 'SELECT id, room_id, title, description ,';
+  sql += ' to_char(start_at, \'YYYY-MM-DD"T"HH24:MI:SS"Z"\') AS start_at, ';
+  sql += ' to_char(end_at, \'YYYY-MM-DD"T"HH24:MI:SS"Z"\') AS end_at, ';
+  sql += ' to_char(registered_at, \'YYYY-MM-DD"T"HH24:MI:SS"Z"\') AS registered_at';
+  sql += ' FROM meetings WHERE $(from) <= end_at';
   if (params.room_id) {
     sql += ' AND room_id = $(room_id)';
   }

--- a/routes/meetings.js
+++ b/routes/meetings.js
@@ -3,6 +3,19 @@ const router = express.Router(); // eslint-disable-line new-cap
 const pgp = require('pg-promise')();
 const db = pgp(process.env.DATABASE_URL);
 
+router.get('/', (req, res, next) => {
+  db.any('SELECT * FROM meetings ORDER BY start_at')
+  .then((data) => res.status(200).json(data))
+  .catch((err) => next(err));
+});
+
+router.get('/:room_id', (req, res, next) => {
+  db.any('SELECT * FROM meetings WHERE room_id = $1 ORDER BY start_at',
+    [req.params.room_id])
+  .then((data) => res.status(200).json(data))
+  .catch((err) => next(err));
+});
+
 function getCreatedMeetings(req) {
   if (!Array.isArray(req.body)) {
     return [];


### PR DESCRIPTION
Issue #7

取得用のエンドポイントを実装しました。
- GET /api/meetings
- GET /api/meetings/{room_id}
- GET /api/meetings/{room_id}?limit=1
- GET /api/meetings/{room_id}?from=2016-06-21T01:00:00.000Z&to=2016-06-21T01:00:00.000Z

テストデータの登録。終了した会議は表示しないので、`start_at` を現在時刻に合わせて調整してください。

``` sh
$ curl -X POST -H "Content-Type: application/json" --data '[
{"room_id": "A", "title": "A-1", "start_at": "2016-06-29T01:00:00Z", "end_at": "2016-06-29T02:00:00Z"},
{"room_id": "A", "title": "A-2", "start_at": "2016-06-29T05:00:00Z", "end_at": "2016-06-29T06:00:00Z"},
{"room_id": "A", "title": "A-3", "start_at": "2016-06-30T02:30:00Z", "end_at": "2016-06-30T03:30:00Z"},
{"room_id": "B", "title": "B-1", "start_at": "2016-06-30T10:30:00+09:00", "end_at": "2016-06-30T11:30:00+09:00"}
]' http://localhost:5000/api/meetings

{"status":201,"message":"Created"}

$ psql -c "select * from meetings" <DB名>
 id | room_id | title | description |      start_at       |       end_at        |    registered_at
----+---------+-------+-------------+---------------------+---------------------+---------------------
 21 | A       | A-1   |             | 2016-06-29 01:00:00 | 2016-06-29 02:00:00 | 2016-06-29 05:34:09
 22 | A       | A-2   |             | 2016-06-29 05:00:00 | 2016-06-29 06:00:00 | 2016-06-29 05:34:09
 23 | A       | A-3   |             | 2016-06-30 02:30:00 | 2016-06-30 03:30:00 | 2016-06-29 05:34:09
 24 | B       | B-1   |             | 2016-06-30 01:30:00 | 2016-06-30 02:30:00 | 2016-06-29 05:34:09
(4 rows)
```

スケジュールの取得。全件取得と個別取得。

``` sh
$ curl -s http://localhost:5000/api/meetings | jq .
[
  {
    "id": 22,
    "room_id": "A",
    "title": "A-2",
    "description": "",
    "start_at": "2016-06-29T05:00:00Z",
    "end_at": "2016-06-29T06:00:00Z",
    "registered_at": "2016-06-29T05:34:09Z"
  },
  {
    "id": 24,
    "room_id": "B",
    "title": "B-1",
    "description": "",
    "start_at": "2016-06-30T01:30:00Z",
    "end_at": "2016-06-30T02:30:00Z",
    "registered_at": "2016-06-29T05:34:09Z"
  },
  {
    "id": 23,
    "room_id": "A",
    "title": "A-3",
    "description": "",
    "start_at": "2016-06-30T02:30:00Z",
    "end_at": "2016-06-30T03:30:00Z",
    "registered_at": "2016-06-29T05:34:09Z"
  }
]
```

``` sh
$ curl -s http://localhost:5000/api/meetings/B | jq .
[
  {
    "id": 24,
    "room_id": "B",
    "title": "B-1",
    "description": "",
    "start_at": "2016-06-30T01:30:00Z",
    "end_at": "2016-06-30T02:30:00Z",
    "registered_at": "2016-06-29T05:34:09Z"
  }
]
```

取得件数を直近の1件に絞り込む。

``` sh
$ curl -s 'http://localhost:5000/api/meetings/A?limit=1' | jq .
[
  {
    "id": 22,
    "room_id": "A",
    "title": "A-2",
    "description": "",
    "start_at": "2016-06-29T05:00:00Z",
    "end_at": "2016-06-29T06:00:00Z",
    "registered_at": "2016-06-29T05:34:09Z"
  }
]
```
