### PR TITLE
終了通知判定用のAPIを実装

### DIFF
--- a/routes/meetings.js
+++ b/routes/meetings.js
@@ -40,6 +40,23 @@ router.get('/:room_id', (req, res, next) => {
   .catch((err) => next(err));
 });
 
+router.get('/:room_id/pow', (req, res, next) => {
+  const threshold = req.query.threshold || 10;
+  findMeetings(req)
+  .then((data) => {
+    if (data.length > 0) {
+      const endAt = new Date(data[0].end_at);
+      const remainingMillisec = endAt.getTime() - new Date().getTime();
+      if (remainingMillisec / 1000 / 60 <= threshold) {
+        res.status(200).json({ notification: true });
+        return;
+      }
+    }
+    res.status(200).json({ notification: false });
+  })
+  .catch((err) => next(err));
+});
+
 function getCreatedMeetings(req) {
   if (!Array.isArray(req.body)) {
     return [];


### PR DESCRIPTION
refs  #14

終了判定用のAPIを実装したので、確認をお願いします。
- GET /api/meetings/{room_id}/pow
  - 終了時刻まで10分以下になったら `{"notification":true}`
  - それ以外の場合は `{"notification":false}`
- GET /api/meetings/{room_id}/pow?threshold={N}
  - しきい値が {N} 分になる以外は同じ
